### PR TITLE
bug fix #58 on documentation

### DIFF
--- a/PillarChap/Pillar.pillar
+++ b/PillarChap/Pillar.pillar
@@ -851,7 +851,7 @@ interchange format (similar to the popular *JSON>http://www.json.org*.
 @configParameters
 
 [[[language=smalltalk|eval=true
-    CCDocumentationGeneration of: PRCocoonConfiguration on: stream.
+    CCDocumentationGeneration of: PRPillarConfiguration on: stream.
 ]]]
 
 !! Templating


### PR DESCRIPTION
I have fix the Pillar documentation bug of chapter "Configuration parameter".
bug #58.
It was a version bug, the PRCocoonConfiguration has been changed in PRPillarConfiguration :
https://github.com/pillar-markup/pillar/issues/86