### PR TITLE
download.sh uses pillar stable

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 VM_INSTALL_URL="http://get.pharo.org/vm"
-IMAGE_URL="https://ci.inria.fr/pharo-contribution/job/Pillar/PHARO=40,VERSION=development,VM=vm/lastSuccessfulBuild/artifact/Pillar.zip"
+IMAGE_URL="https://ci.inria.fr/pharo-contribution/job/Pillar/PHARO=40,VERSION=stable,VM=vm/lastSuccessfulBuild/artifact/Pillar.zip"
 PHARO_VM=${PHARO_VM:-./pharo}
 
 usage() {


### PR DESCRIPTION
I have updated the script because the development version is going to go through big changes.
So i changed the downloaded version for "stable" which is the ancient development version.